### PR TITLE
Update identity attributes in example

### DIFF
--- a/sections/authentication.md
+++ b/sections/authentication.md
@@ -102,7 +102,8 @@ This endpoint should be first request made after you've obtained a user's author
   "expires_at": "2012-03-22T16:56:48-05:00",
   "identity": {
     "id": 9999999,
-    "name": "Jason Fried",
+    "first_name": "Jason",
+    "last_name": "Fried",
     "email_address": "jason@basecamp.com",
   },
   "accounts": [


### PR DESCRIPTION
I noticed that this example indicates that a `name` attribute is available inside of `identity`, and this doesn't appear to be the case. Only `first_name` and `last_name` are available.