### PR TITLE
Fix link to integrations section of Launchpad

### DIFF
--- a/sections/authentication.md
+++ b/sections/authentication.md
@@ -42,7 +42,7 @@ ask a user for access to their account. You get an API access token back without
 ever having to see their password or ask them to copy/paste an API key.
 
 1. [Grab an OAuth 2 library](http://oauth.net/code/).
-2. Register your app at [launchpad.37signals.com](https://launchpad.37signals.com). You'll be assigned a `client_id` and `client_secret`. You'll need to provide a `redirect_uri`: a URL where we can send a verification code. Just enter a dummy URL like `http://myapp.com/oauth` if you're not ready for this yet.
+2. Register your app at [launchpad.37signals.com](https://launchpad.37signals.com/integrations). You'll be assigned a `client_id` and `client_secret`. You'll need to provide a `redirect_uri`: a URL where we can send a verification code. Just enter a dummy URL like `http://myapp.com/oauth` if you're not ready for this yet.
 3. Configure your OAuth 2 library with your `client_id`, `client_secret`, and `redirect_uri`. Tell it to use `https://launchpad.37signals.com/authorization/new` to request authorization and `https://launchpad.37signals.com/authorization/token` to get access tokens.
 4. Try making an authorized request to `https://launchpad.37signals.com/authorization.json` to dig in and test it out! Check out the [Get authorization](#get-authorization) endpoint for a description of what this returns.
 


### PR DESCRIPTION
Linking to the root of launchpad.37signals.com just redirects users to their current Basecamp